### PR TITLE
fix: open and close blockstore during interface tests

### DIFF
--- a/packages/interface-blockstore-tests/src/index.ts
+++ b/packages/interface-blockstore-tests/src/index.ts
@@ -45,9 +45,13 @@ export function interfaceBlockstoreTests (test: { teardown: () => void, setup: (
 
     beforeEach(async () => {
       store = await createStore()
+      await store.open()
     })
 
-    afterEach(async () => { await cleanup(store) })
+    afterEach(async () => {
+      await store.close()
+      await cleanup(store)
+    })
 
     it('simple', async () => {
       const { key, value } = await getKeyValuePair()


### PR DESCRIPTION
Store needs to be opened and closed.