### PR TITLE
feat!: simplify store interface, move query/batch to datastore, add getAll to blockstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 node_modules
+build
 dist
 .docs
 .coverage
 node_modules
 package-lock.json
 yarn.lock
+.vscode

--- a/packages/interface-blockstore-tests/package.json
+++ b/packages/interface-blockstore-tests/package.json
@@ -23,22 +23,6 @@
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ],
-      "src/*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ]
-    }
-  },
   "files": [
     "src",
     "dist",

--- a/packages/interface-blockstore-tests/package.json
+++ b/packages/interface-blockstore-tests/package.json
@@ -154,7 +154,6 @@
     "interface-blockstore": "^4.0.0",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",
-    "it-length": "^2.0.0",
     "multiformats": "^11.0.0",
     "uint8arrays": "^4.0.2"
   },

--- a/packages/interface-blockstore-tests/src/index.ts
+++ b/packages/interface-blockstore-tests/src/index.ts
@@ -6,17 +6,16 @@ import drain from 'it-drain'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { CID } from 'multiformats/cid'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { base32 } from 'multiformats/bases/base32'
 import * as raw from 'multiformats/codecs/raw'
-import length from 'it-length'
-import type { Blockstore, KeyQueryFilter, KeyQueryOrder, Pair, QueryFilter, QueryOrder } from 'interface-blockstore'
+import type { Blockstore, Pair } from 'interface-blockstore'
+import { base32 } from 'multiformats/bases/base32'
 
 async function getKeyValuePair (data?: string): Promise<Pair> {
-  const value = uint8ArrayFromString(data ?? `data-${Math.random()}`)
-  const hash = await sha256.digest(value)
-  const key = CID.createV1(raw.code, hash)
+  const block = uint8ArrayFromString(data ?? `data-${Math.random()}`)
+  const hash = await sha256.digest(block)
+  const cid = CID.createV1(raw.code, hash)
 
-  return { key, value }
+  return { cid, block }
 }
 
 async function getKeyValuePairs (count: number): Promise<Pair[]> {
@@ -25,103 +24,110 @@ async function getKeyValuePairs (count: number): Promise<Pair[]> {
   )
 }
 
-export function interfaceBlockstoreTests (test: { teardown: () => void, setup: () => Blockstore }): void {
-  const cleanup = async (store: Blockstore): Promise<void> => {
-    await store.close()
-    test.teardown()
+export interface InterfaceBlockstoreTest<B extends Blockstore = Blockstore> {
+  setup: () => B | Promise<B>
+  teardown: (store: B) => void | Promise<void>
+}
+
+export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (test: InterfaceBlockstoreTest<B>): void {
+  const cleanup = async (store: B): Promise<void> => {
+    await test.teardown(store)
   }
 
-  const createStore = async (): Promise<Blockstore> => {
-    const store = test.setup()
+  const createStore = async (): Promise<B> => {
+    const store = await test.setup()
+
     if (store == null) {
       throw new Error('missing store')
     }
-    await store.open()
+
     return store
   }
 
   describe('put', () => {
-    let store: Blockstore
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
-      await store.open()
     })
 
     afterEach(async () => {
-      await store.close()
       await cleanup(store)
     })
 
     it('simple', async () => {
-      const { key, value } = await getKeyValuePair()
+      const { cid, block } = await getKeyValuePair()
 
-      await store.put(key, value)
+      await store.put(cid, block)
     })
 
     it('parallel', async () => {
       const data = await getKeyValuePairs(100)
 
-      await Promise.all(data.map(async d => { await store.put(d.key, d.value) }))
+      await Promise.all(data.map(async d => { await store.put(d.cid, d.block) }))
 
-      const res = await all(store.getMany(data.map(d => d.key)))
-      expect(res).to.deep.equal(data.map(d => d.value))
+      const res = await all(store.getMany(data.map(d => d.cid)))
+      expect(res).to.deep.equal(data.map(d => d.block))
     })
   })
 
   describe('putMany', () => {
-    let store: Blockstore
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
     })
 
-    afterEach(async () => { await cleanup(store) })
+    afterEach(async () => {
+      await cleanup(store)
+    })
 
     it('streaming', async () => {
       const data = await getKeyValuePairs(100)
 
       let index = 0
 
-      for await (const { key, value } of store.putMany(data)) {
-        expect(data[index]).to.deep.equal({ key, value })
+      for await (const { cid, block } of store.putMany(data)) {
+        expect(data[index]).to.deep.equal({ cid, block })
         index++
       }
 
       expect(index).to.equal(data.length)
 
-      const res = await all(store.getMany(data.map(d => d.key)))
-      expect(res).to.deep.equal(data.map(d => d.value))
+      const res = await all(store.getMany(data.map(d => d.cid)))
+      expect(res).to.deep.equal(data.map(d => d.block))
     })
   })
 
   describe('get', () => {
-    let store: Blockstore
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
     })
 
-    afterEach(async () => { await cleanup(store) })
+    afterEach(async () => {
+      await cleanup(store)
+    })
 
     it('simple', async () => {
       const {
-        key, value
+        cid, block
       } = await getKeyValuePair()
 
-      await store.put(key, value)
+      await store.put(cid, block)
 
-      const res = await store.get(key)
-      expect(res).to.equalBytes(value)
+      const res = await store.get(cid)
+      expect(res).to.equalBytes(block)
     })
 
     it('should throw error for missing key', async () => {
       const {
-        key
+        cid
       } = await getKeyValuePair()
 
       try {
-        await store.get(key)
+        await store.get(cid)
       } catch (err) {
         expect(err).to.have.property('code', 'ERR_NOT_FOUND')
         return
@@ -132,34 +138,36 @@ export function interfaceBlockstoreTests (test: { teardown: () => void, setup: (
   })
 
   describe('getMany', () => {
-    let store: Blockstore
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
     })
 
-    afterEach(async () => { await cleanup(store) })
+    afterEach(async () => {
+      await cleanup(store)
+    })
 
     it('streaming', async () => {
       const {
-        key, value
+        cid, block
       } = await getKeyValuePair()
 
-      await store.put(key, value)
-      const source = [key]
+      await store.put(cid, block)
+      const source = [cid]
 
       const res = await all(store.getMany(source))
       expect(res).to.have.lengthOf(1)
-      expect(res[0]).to.equalBytes(value)
+      expect(res[0]).to.equalBytes(block)
     })
 
     it('should throw error for missing key', async () => {
       const {
-        key
+        cid
       } = await getKeyValuePair()
 
       try {
-        await drain(store.getMany([key]))
+        await drain(store.getMany([cid]))
       } catch (err) {
         expect(err).to.have.property('code', 'ERR_NOT_FOUND')
         return
@@ -170,415 +178,110 @@ export function interfaceBlockstoreTests (test: { teardown: () => void, setup: (
   })
 
   describe('delete', () => {
-    let store: Blockstore
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
     })
 
-    afterEach(async () => { await cleanup(store) })
+    afterEach(async () => {
+      await cleanup(store)
+    })
 
     it('simple', async () => {
       const {
-        key, value
+        cid, block
       } = await getKeyValuePair()
 
-      await store.put(key, value)
-      await store.get(key)
-      await store.delete(key)
-      const exists = await store.has(key)
+      await store.put(cid, block)
+      await store.get(cid)
+      await store.delete(cid)
+      const exists = await store.has(cid)
       expect(exists).to.be.eql(false)
     })
 
     it('parallel', async () => {
       const data = await getKeyValuePairs(100)
 
-      await Promise.all(data.map(async d => { await store.put(d.key, d.value) }))
+      await Promise.all(data.map(async d => { await store.put(d.cid, d.block) }))
 
-      const res0 = await Promise.all(data.map(async d => await store.has(d.key)))
+      const res0 = await Promise.all(data.map(async d => await store.has(d.cid)))
       res0.forEach(res => expect(res).to.be.eql(true))
 
-      await Promise.all(data.map(async d => { await store.delete(d.key) }))
+      await Promise.all(data.map(async d => { await store.delete(d.cid) }))
 
-      const res1 = await Promise.all(data.map(async d => await store.has(d.key)))
+      const res1 = await Promise.all(data.map(async d => await store.has(d.cid)))
       res1.forEach(res => expect(res).to.be.eql(false))
     })
   })
 
   describe('deleteMany', () => {
-    let store: Blockstore
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
     })
 
-    afterEach(async () => { await cleanup(store) })
+    afterEach(async () => {
+      await cleanup(store)
+    })
 
     it('streaming', async () => {
       const data = await getKeyValuePairs(100)
 
       await drain(store.putMany(data))
 
-      const res0 = await Promise.all(data.map(async d => await store.has(d.key)))
+      const res0 = await Promise.all(data.map(async d => await store.has(d.cid)))
       res0.forEach(res => expect(res).to.be.eql(true))
 
       let index = 0
 
-      for await (const key of store.deleteMany(data.map(d => d.key))) {
-        expect(data[index].key).to.deep.equal(key)
+      for await (const key of store.deleteMany(data.map(d => d.cid))) {
+        expect(data[index].cid).to.deep.equal(key)
         index++
       }
 
       expect(index).to.equal(data.length)
 
-      const res1 = await Promise.all(data.map(async d => await store.has(d.key)))
+      const res1 = await Promise.all(data.map(async d => await store.has(d.cid)))
       res1.forEach(res => expect(res).to.be.eql(false))
     })
   })
 
-  describe('batch', () => {
-    let store: Blockstore
+  describe('blocks', () => {
+    let store: B
 
     beforeEach(async () => {
       store = await createStore()
     })
 
-    afterEach(async () => { await cleanup(store) })
-
-    it('simple', async () => {
-      const data = await getKeyValuePairs(4)
-
-      const b = store.batch()
-
-      await store.put(data[0].key, data[0].value)
-
-      b.put(data[1].key, data[1].value)
-      b.put(data[2].key, data[2].value)
-      b.put(data[3].key, data[3].value)
-      b.delete(data[0].key)
-      await b.commit()
-
-      const keys = data.map(d => d.key)
-      const res = await Promise.all(keys.map(async k => await store.has(k)))
-
-      expect(res).to.be.eql([false, true, true, true])
+    afterEach(async () => {
+      await cleanup(store)
     })
 
-    it('many (100)', async function () {
-      this.timeout(320 * 1000)
-      const b = store.batch()
-      const count = 100
+    it('returns all blocks', async () => {
+      const data = await getKeyValuePairs(100)
 
-      const prefixes: Record<string, number> = {}
+      await drain(store.putMany(data))
 
-      for (let i = 0; i < count; i++) {
-        const {
-          key, value
-        } = await getKeyValuePair()
+      const allBlocks = await all(store.getAll())
 
-        b.put(key, value)
+      expect(allBlocks).of.have.lengthOf(data.length)
 
-        // find the shortest stringified key that aligns with a byte boundary
-        const keyStr = key.toString()
-        let prefix = ''
+      // order is not preserved
+      for (const { cid, block } of data) {
+        const retrievedPair = allBlocks.find(pair => {
+          return base32.encode(cid.multihash.bytes) === base32.encode(pair.cid.multihash.bytes)
+        })
 
-        for (let j = keyStr.length - 1; j > 20; j--) {
-          try {
-            base32.decode(keyStr.substring(0, j))
-            prefix = keyStr.substring(0, j)
-          } catch (err: any) {
-            if (err.message !== 'Unexpected end of data') {
-              throw err
-            }
-          }
+        expect(retrievedPair).to.be.ok()
+
+        if (retrievedPair == null) {
+          throw new Error('Could not find cid/block pair')
         }
 
-        prefixes[prefix] = (prefixes[prefix] ?? 0) + 1
+        expect(retrievedPair.block).to.equalBytes(block)
       }
-
-      await b.commit()
-
-      await Promise.all(
-        Object.keys(prefixes)
-          .map(async prefix => {
-            await expect(length(store.query({ prefix }))).to.eventually.equal(prefixes[prefix])
-          })
-      )
-    })
-  })
-
-  describe('query', () => {
-    let store: Blockstore
-    let hello: Pair
-    let world: Pair
-    let hello2: Pair
-    let filter1: QueryFilter
-    let filter2: QueryFilter
-
-    before(async () => {
-      hello = await getKeyValuePair('hello')
-      hello2 = await getKeyValuePair('hello2')
-      world = await getKeyValuePair('world')
-
-      filter1 = entry => !entry.key.toString().endsWith(hello.key.toString().substring(-5))
-      filter2 = entry => entry.key.toString().endsWith(hello2.key.toString().substring(-5))
-    })
-
-    const order1: QueryOrder = (a, b) => {
-      if (a.value.toString() < b.value.toString()) {
-        return -1
-      }
-      return 1
-    }
-
-    const order2: QueryOrder = (a, b) => {
-      if (a.value.toString() < b.value.toString()) {
-        return 1
-      }
-      if (a.value.toString() > b.value.toString()) {
-        return -1
-      }
-      return 0
-    }
-
-    const tests: Array<{ name: string, test: () => { query: any, expected: any } }> = [
-      { name: 'empty', test: () => ({ query: {}, expected: [hello, world, hello2] }) },
-      { name: 'prefix', test: () => ({ query: { prefix: hello.key.toString().charAt(0) }, expected: [hello, world, hello2] }) },
-      { name: '1 filter', test: () => ({ query: { filters: [filter1] }, expected: [world, hello2] }) },
-      { name: '2 filters', test: () => ({ query: { filters: [filter1, filter2] }, expected: [hello2] }) },
-      { name: 'limit', test: () => ({ query: { limit: 1 }, expected: 1 }) },
-      { name: 'offset', test: () => ({ query: { offset: 1 }, expected: 2 }) },
-      { name: '1 order (1)', test: () => ({ query: { orders: [order1] }, expected: [hello, hello2, world] }) },
-      { name: '1 order (reverse 1)', test: () => ({ query: { orders: [order2] }, expected: [world, hello2, hello] }) }
-    ]
-
-    before(async () => {
-      store = await createStore()
-
-      const b = store.batch()
-
-      b.put(hello.key, hello.value)
-      b.put(world.key, world.value)
-      b.put(hello2.key, hello2.value)
-
-      await b.commit()
-    })
-
-    after(async () => { await cleanup(store) })
-
-    tests.forEach(({ name, test }) => it(name, async () => {
-      const {
-        query, expected
-      } = test()
-      let res = await all(store.query(query))
-
-      if (Array.isArray(expected)) {
-        if (query.orders == null) {
-          expect(res).to.have.length(expected.length)
-          const s = (a: Pair, b: Pair): number => {
-            if (a.key.toString() < b.key.toString()) {
-              return 1
-            } else {
-              return -1
-            }
-          }
-          res = res.sort(s)
-          const exp = expected.sort(s)
-
-          res.forEach((r, i) => {
-            expect(r.key.toString()).to.be.eql(exp[i].key.toString())
-
-            if (r.value == null) {
-              expect(exp[i].value).to.not.exist()
-            } else {
-              expect(r.value).to.deep.equal(exp[i].value)
-            }
-          })
-        } else {
-          expect(res).to.be.eql(expected)
-        }
-      } else if (typeof expected === 'number') {
-        expect(res).to.have.length(expected)
-      }
-    }))
-
-    it('allows mutating the datastore during a query', async () => {
-      const hello3 = await getKeyValuePair()
-      let firstIteration = true
-
-      for await (const {} of store.query({})) { // eslint-disable-line no-empty-pattern
-        if (firstIteration) {
-          expect(await store.has(hello2.key)).to.be.true()
-          await store.delete(hello2.key)
-          expect(await store.has(hello2.key)).to.be.false()
-
-          await store.put(hello3.key, hello3.value)
-          firstIteration = false
-        }
-      }
-
-      const results = await all(store.query({}))
-
-      expect(firstIteration).to.be.false('Query did not return anything')
-      expect(results.map(result => result.key)).to.have.deep.members([
-        hello.key,
-        world.key,
-        hello3.key
-      ])
-    })
-
-    it('queries while the datastore is being mutated', async () => {
-      const {
-        key, value
-      } = await getKeyValuePair()
-      const writePromise = store.put(key, value)
-      const results = await all(store.query({}))
-      expect(results.length).to.be.greaterThan(0)
-      await writePromise
-    })
-  })
-
-  describe('queryKeys', () => {
-    let store: Blockstore
-    let hello: Pair
-    let world: Pair
-    let hello2: Pair
-    let filter1: KeyQueryFilter
-    let filter2: KeyQueryFilter
-
-    before(async () => {
-      hello = await getKeyValuePair('hello')
-      hello2 = await getKeyValuePair('hello2')
-      world = await getKeyValuePair('world')
-
-      filter1 = key => !key.toString().endsWith(hello.key.toString().substring(-5))
-      filter2 = key => key.toString().endsWith(hello2.key.toString().substring(-5))
-    })
-
-    const order1: KeyQueryOrder = (a, b) => {
-      if (a.toString() < b.toString()) {
-        return -1
-      }
-      return 1
-    }
-
-    const order2: KeyQueryOrder = (a, b) => {
-      if (a.toString() < b.toString()) {
-        return 1
-      }
-      if (a.toString() > b.toString()) {
-        return -1
-      }
-      return 0
-    }
-
-    const tests: Array<{ name: string, test: () => { query: any, expected: any } }> = [
-      { name: 'empty', test: () => ({ query: {}, expected: [hello.key, world.key, hello2.key] }) },
-      { name: 'prefix', test: () => ({ query: { prefix: hello.key.toString().charAt(0) }, expected: [hello.key, world.key, hello2.key] }) },
-      { name: '1 filter', test: () => ({ query: { filters: [filter1] }, expected: [world.key, hello2.key] }) },
-      { name: '2 filters', test: () => ({ query: { filters: [filter1, filter2] }, expected: [hello2.key] }) },
-      { name: 'limit', test: () => ({ query: { limit: 1 }, expected: 1 }) },
-      { name: 'offset', test: () => ({ query: { offset: 1 }, expected: 2 }) },
-      { name: '1 order (1)', test: () => ({ query: { orders: [order1] }, expected: [hello.key, world.key, hello2.key] }) },
-      { name: '1 order (reverse 1)', test: () => ({ query: { orders: [order2] }, expected: [hello2.key, world.key, hello.key] }) }
-    ]
-
-    before(async () => {
-      store = await createStore()
-
-      const b = store.batch()
-
-      b.put(hello.key, hello.value)
-      b.put(world.key, world.value)
-      b.put(hello2.key, hello2.value)
-
-      await b.commit()
-    })
-
-    after(async () => { await cleanup(store) })
-
-    tests.forEach(({ name, test }) => it(name, async () => {
-      const {
-        query, expected
-      } = test()
-      let res = await all(store.queryKeys(query))
-
-      if (Array.isArray(expected)) {
-        if (query.orders == null) {
-          expect(res).to.have.length(expected.length)
-
-          const s: KeyQueryOrder = (a, b) => {
-            if (a.toString() < b.toString()) {
-              return 1
-            } else {
-              return -1
-            }
-          }
-          res = res.sort(s)
-          const exp = expected.sort(s)
-
-          res.forEach((r, i) => {
-            expect(r.toString()).to.be.eql(exp[i].toString())
-          })
-        } else {
-          expect(res).to.be.eql(expected)
-        }
-      } else if (typeof expected === 'number') {
-        expect(res).to.have.length(expected)
-      }
-    }))
-
-    it('allows mutating the datastore during a query', async () => {
-      const hello3 = await getKeyValuePair()
-      let firstIteration = true
-
-      for await (const {} of store.queryKeys({})) { // eslint-disable-line no-empty-pattern
-        if (firstIteration) {
-          expect(await store.has(hello2.key)).to.be.true()
-          await store.delete(hello2.key)
-          expect(await store.has(hello2.key)).to.be.false()
-
-          await store.put(hello3.key, hello3.value)
-          firstIteration = false
-        }
-      }
-
-      const results = await all(store.queryKeys({}))
-
-      expect(firstIteration).to.be.false('Query did not return anything')
-      expect(results).to.have.deep.members([
-        hello.key,
-        world.key,
-        hello3.key
-      ])
-    })
-
-    it('queries while the datastore is being mutated', async () => {
-      const { key, value } = await getKeyValuePair()
-      const writePromise = store.put(key, value)
-      const results = await all(store.queryKeys({}))
-      expect(results.length).to.be.greaterThan(0)
-      await writePromise
-    })
-  })
-
-  describe('lifecycle', () => {
-    let store: Blockstore
-
-    before(() => {
-      store = test.setup()
-      if (store == null) {
-        throw new Error('missing store')
-      }
-    })
-
-    after(async () => { await cleanup(store) })
-
-    it('close and open', async () => {
-      await store.close()
-      await store.open()
-      await store.close()
-      await store.open()
     })
   })
 }

--- a/packages/interface-blockstore/src/index.ts
+++ b/packages/interface-blockstore/src/index.ts
@@ -3,28 +3,26 @@ import type {
   AwaitIterable,
   Store
 } from 'interface-store'
-import type {
-  CID
-} from 'multiformats'
+import type { MultihashDigest } from 'multiformats/hashes/digest'
 
 export interface Options extends StoreOptions {
 
 }
 
 export interface Pair {
-  cid: CID
+  multihash: MultihashDigest
   block: Uint8Array
 }
 
-export interface Blockstore extends Store<CID, Uint8Array, Pair> {
+export interface Blockstore extends Store<MultihashDigest, Uint8Array, Pair> {
   /**
    * Retrieve all cid/block pairs from the blockstore as an unordered iterable
    *
    * @example
    * ```js
-   * for await (const { cid, block } of store.getAll()) {
-   *   console.log('got:', cid, block)
-   *   // => got CID('Qmfoo') Uint8Array[...]
+   * for await (const { multihash, block } of store.getAll()) {
+   *   console.log('got:', multihash, block)
+   *   // => got MultihashDigest('Qmfoo') Uint8Array[...]
    * }
    * ```
    */

--- a/packages/interface-blockstore/src/index.ts
+++ b/packages/interface-blockstore/src/index.ts
@@ -3,18 +3,18 @@ import type {
   AwaitIterable,
   Store
 } from 'interface-store'
-import type { MultihashDigest } from 'multiformats/hashes/digest'
+import type { CID } from 'multiformats/cid'
 
 export interface Options extends StoreOptions {
 
 }
 
 export interface Pair {
-  multihash: MultihashDigest
+  cid: CID
   block: Uint8Array
 }
 
-export interface Blockstore extends Store<MultihashDigest, Uint8Array, Pair> {
+export interface Blockstore extends Store<CID, Uint8Array, Pair> {
   /**
    * Retrieve all cid/block pairs from the blockstore as an unordered iterable
    *

--- a/packages/interface-blockstore/src/index.ts
+++ b/packages/interface-blockstore/src/index.ts
@@ -1,13 +1,6 @@
 import type {
-  Pair as StorePair,
-  Batch as StoreBatch,
-  QueryFilter as StoreQueryFilter,
-  QueryOrder as StoreQueryOrder,
-  Query as StoreQuery,
-  KeyQueryFilter as StoreKeyQueryFilter,
-  KeyQueryOrder as StoreKeyQueryOrder,
-  KeyQuery as StoreKeyQuery,
   Options as StoreOptions,
+  AwaitIterable,
   Store
 } from 'interface-store'
 import type {
@@ -18,38 +11,22 @@ export interface Options extends StoreOptions {
 
 }
 
-export interface Pair extends StorePair<CID, Uint8Array> {
-
+export interface Pair {
+  cid: CID
+  block: Uint8Array
 }
 
-export interface Batch extends StoreBatch<CID, Uint8Array> {
-
-}
-
-export interface Blockstore extends Store<CID, Uint8Array> {
-
-}
-
-export interface QueryFilter extends StoreQueryFilter<CID, Uint8Array> {
-
-}
-
-export interface QueryOrder extends StoreQueryOrder<CID, Uint8Array> {
-
-}
-
-export interface Query extends StoreQuery<CID, Uint8Array> {
-
-}
-
-export interface KeyQueryFilter extends StoreKeyQueryFilter<CID> {
-
-}
-
-export interface KeyQueryOrder extends StoreKeyQueryOrder<CID> {
-
-}
-
-export interface KeyQuery extends StoreKeyQuery<CID> {
-
+export interface Blockstore extends Store<CID, Uint8Array, Pair> {
+  /**
+   * Retrieve all cid/block pairs from the blockstore as an unordered iterable
+   *
+   * @example
+   * ```js
+   * for await (const { cid, block } of store.getAll()) {
+   *   console.log('got:', cid, block)
+   *   // => got CID('Qmfoo') Uint8Array[...]
+   * }
+   * ```
+   */
+  getAll: (options?: Options) => AwaitIterable<Pair>
 }

--- a/packages/interface-datastore-tests/package.json
+++ b/packages/interface-datastore-tests/package.json
@@ -23,22 +23,6 @@
   },
   "type": "module",
   "types": "./dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ],
-      "src/*": [
-        "*",
-        "dist/*",
-        "dist/src/*",
-        "dist/src/*/index"
-      ]
-    }
-  },
   "files": [
     "src",
     "dist",

--- a/packages/interface-datastore-tests/package.json
+++ b/packages/interface-datastore-tests/package.json
@@ -32,7 +32,7 @@
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
-      "import": "./src/index.js"
+      "import": "./dist/src/index.js"
     }
   },
   "eslintConfig": {
@@ -143,6 +143,6 @@
     "uint8arrays": "^4.0.2"
   },
   "typedoc": {
-    "entryPoint": "./src/index.js"
+    "entryPoint": "./src/index.ts"
   }
 }

--- a/packages/interface-datastore-tests/package.json
+++ b/packages/interface-datastore-tests/package.json
@@ -155,6 +155,7 @@
     "iso-random-stream": "^2.0.0",
     "it-all": "^2.0.0",
     "it-drain": "^2.0.0",
+    "it-length": "^2.0.1",
     "uint8arrays": "^4.0.2"
   },
   "typedoc": {

--- a/packages/interface-datastore-tests/tsconfig.json
+++ b/packages/interface-datastore-tests/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "emitDeclarationOnly": true
+    "outDir": "dist"
   },
   "include": [
     "src"

--- a/packages/interface-datastore/src/index.ts
+++ b/packages/interface-datastore/src/index.ts
@@ -1,13 +1,6 @@
 import type {
-  Pair as StorePair,
-  Batch as StoreBatch,
-  QueryFilter as StoreQueryFilter,
-  QueryOrder as StoreQueryOrder,
-  Query as StoreQuery,
-  KeyQueryFilter as StoreKeyQueryFilter,
-  KeyQueryOrder as StoreKeyQueryOrder,
-  KeyQuery as StoreKeyQuery,
   Options as StoreOptions,
+  Await,
   Store
 } from 'interface-store'
 import { Key } from './key.js'
@@ -16,40 +9,86 @@ export interface Options extends StoreOptions {
 
 }
 
-export interface Pair extends StorePair<Key, Uint8Array> {
-
+export interface Pair {
+  key: Key
+  value: Uint8Array
 }
 
-export interface Batch extends StoreBatch<Key, Uint8Array> {
-
+export interface Batch {
+  put: (key: Key, value: Uint8Array) => void
+  delete: (key: Key) => void
+  commit: (options?: Options) => Await<void>
 }
 
-export interface Datastore extends Store<Key, Uint8Array> {
+export interface Datastore extends Store<Key, Uint8Array, Pair> {
+  /**
+   * This will return an object with which you can chain multiple operations together, with them only being executed on calling `commit`.
+   *
+   * @example
+   * ```js
+   * const b = store.batch()
+   *
+   * for (let i = 0; i < 100; i++) {
+   *   b.put(new Key(`hello${i}`), new TextEncoder('utf8').encode(`hello world ${i}`))
+   * }
+   *
+   * await b.commit()
+   * console.log('put 100 values')
+   * ```
+   */
+  batch: () => Batch
 
+  /**
+   * Query the datastore.
+   *
+   * @example
+   * ```js
+   * // retrieve __all__ key/value pairs from the store
+   * let list = []
+   * for await (const { key, value } of store.query({})) {
+   *   list.push(value)
+   * }
+   * console.log('ALL THE VALUES', list)
+   * ```
+   */
+  query: (query: Query, options?: Options) => AsyncIterable<Pair>
+
+  /**
+   * Query the datastore.
+   *
+   * @example
+   * ```js
+   * // retrieve __all__ keys from the store
+   * let list = []
+   * for await (const key of store.queryKeys({})) {
+   *   list.push(key)
+   * }
+   * console.log('ALL THE KEYS', key)
+   * ```
+   */
+  queryKeys: (query: KeyQuery, options?: Options) => AsyncIterable<Key>
 }
 
-export interface QueryFilter extends StoreQueryFilter<Key, Uint8Array> {
+export interface QueryFilter { (item: Pair): boolean }
+export interface QueryOrder { (a: Pair, b: Pair): -1 | 0 | 1 }
 
+export interface Query {
+  prefix?: string
+  filters?: QueryFilter[]
+  orders?: QueryOrder[]
+  limit?: number
+  offset?: number
 }
 
-export interface QueryOrder extends StoreQueryOrder<Key, Uint8Array> {
+export interface KeyQueryFilter { (item: Key): boolean }
+export interface KeyQueryOrder { (a: Key, b: Key): -1 | 0 | 1 }
 
-}
-
-export interface Query extends StoreQuery<Key, Uint8Array> {
-
-}
-
-export interface KeyQueryFilter extends StoreKeyQueryFilter<Key> {
-
-}
-
-export interface KeyQueryOrder extends StoreKeyQueryOrder<Key> {
-
-}
-
-export interface KeyQuery extends StoreKeyQuery<Key> {
-
+export interface KeyQuery {
+  prefix?: string
+  filters?: KeyQueryFilter[]
+  orders?: KeyQueryOrder[]
+  limit?: number
+  offset?: number
 }
 
 export { Key }


### PR DESCRIPTION
- Removes open/close from store as not every implementation needs them
- Removes query from store as it doesn't make sense for blockstores
- Removes batch from store as storing blocks in memory before writing is a bad idea
- Adds query/batch to datastore interface
- Adds getAll to blockstore interface
- Converts datastore tests to typescript
- Improves typing of datastore/blockstore tests to allow setup/teardown to recieve the right store type to open/close, etc
- Blockstore pair is now `{ cid, block }` instead of `{ key, value }`

BREAKING CHANGE: open/close/batch/query methods have been removed from store interface, query/batch added to datastore, getAll added to blockstore