### PR TITLE
fix!: return stream of pairs from getmany

### DIFF
--- a/packages/interface-blockstore-tests/src/index.ts
+++ b/packages/interface-blockstore-tests/src/index.ts
@@ -67,7 +67,7 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
       await Promise.all(data.map(async d => { await store.put(d.cid, d.block) }))
 
       const res = await all(store.getMany(data.map(d => d.cid)))
-      expect(res).to.deep.equal(data.map(d => d.block))
+      expect(res).to.deep.equal(data)
     })
   })
 
@@ -95,7 +95,7 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
       expect(index).to.equal(data.length)
 
       const res = await all(store.getMany(data.map(d => d.cid)))
-      expect(res).to.deep.equal(data.map(d => d.block))
+      expect(res).to.deep.equal(data)
     })
   })
 
@@ -158,7 +158,8 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
 
       const res = await all(store.getMany(source))
       expect(res).to.have.lengthOf(1)
-      expect(res[0]).to.equalBytes(block)
+      expect(res[0].cid).to.deep.equal(cid)
+      expect(res[0].block).to.equalBytes(block)
     })
 
     it('should throw error for missing key', async () => {

--- a/packages/interface-datastore-tests/src/index.ts
+++ b/packages/interface-datastore-tests/src/index.ts
@@ -5,7 +5,7 @@ import { expect } from 'aegir/chai'
 import all from 'it-all'
 import drain from 'it-drain'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { Datastore, Key, KeyQueryFilter, KeyQueryOrder, QueryFilter, QueryOrder } from 'interface-datastore'
+import { Datastore, Key, KeyQueryFilter, KeyQueryOrder, Pair, QueryFilter, QueryOrder } from 'interface-datastore'
 import length from 'it-length'
 
 export interface InterfacDatastoreTest<D extends Datastore = Datastore> {
@@ -37,7 +37,7 @@ export function interfaceDatastoreTests <D extends Datastore = Datastore> (test:
     })
 
     it('parallel', async () => {
-      const data = []
+      const data: Pair[] = []
       for (let i = 0; i < 100; i++) {
         data.push({ key: new Key(`/z/key${i}`), value: uint8ArrayFromString(`data${i}`) })
       }
@@ -45,7 +45,7 @@ export function interfaceDatastoreTests <D extends Datastore = Datastore> (test:
       await Promise.all(data.map(async d => { await store.put(d.key, d.value) }))
 
       const res = await all(store.getMany(data.map(d => d.key)))
-      expect(res).to.deep.equal(data.map(d => d.value))
+      expect(res).to.deep.equal(data)
     })
   })
 
@@ -59,7 +59,7 @@ export function interfaceDatastoreTests <D extends Datastore = Datastore> (test:
     afterEach(async () => { await cleanup(store) })
 
     it('streaming', async () => {
-      const data = []
+      const data: Pair[] = []
       for (let i = 0; i < 100; i++) {
         data.push({ key: new Key(`/z/key${i}`), value: uint8ArrayFromString(`data${i}`) })
       }
@@ -74,7 +74,7 @@ export function interfaceDatastoreTests <D extends Datastore = Datastore> (test:
       expect(index).to.equal(data.length)
 
       const res = await all(store.getMany(data.map(d => d.key)))
-      expect(res).to.deep.equal(data.map(d => d.value))
+      expect(res).to.deep.equal(data)
     })
   })
 
@@ -124,7 +124,8 @@ export function interfaceDatastoreTests <D extends Datastore = Datastore> (test:
 
       const res = await all(store.getMany(source))
       expect(res).to.have.lengthOf(1)
-      expect(res[0]).to.be.eql(uint8ArrayFromString('hello'))
+      expect(res[0].key).to.be.eql(k)
+      expect(res[0].value).to.be.eql(uint8ArrayFromString('hello'))
     })
 
     it('should throw error for missing key', async () => {

--- a/packages/interface-store/src/index.ts
+++ b/packages/interface-store/src/index.ts
@@ -81,16 +81,16 @@ export interface Store<Key, Value, Pair, HasOptionsExtension = {},
    *
    * @example
    * ```js
-   * for await (const value of store.getMany([new Key('awesome')])) {
-   *   console.log('got content:', new TextDecoder('utf8').decode(value))
-   *   // => got content: datastore
+   * for await (const { key, value } of store.getMany([new Key('awesome')])) {
+   *   console.log(`got "${key}" = "${new TextDecoder('utf8').decode(value)}"`')
+   *   // => got "/awesome" = "datastore"
    * }
    * ```
    */
   getMany: (
     source: AwaitIterable<Key>,
     options?: AbortOptions & GetManyOptionsExtension
-  ) => AwaitIterable<Value>
+  ) => AwaitIterable<Pair>
 
   /**
    * Remove the record for the passed key


### PR DESCRIPTION
To make the return value of getMany consistent with putMany and getAll, return a stream of pairs from the return type of getMany - this also allows decoupling of processing the output from the input since the output processor doesn't need any extra context since they get both the key and the value being returned.

BREAKING CHANGE: the output of store.getMany is now a stream of pairs