### PR TITLE
fix: return key from put and put many

### DIFF
--- a/packages/interface-blockstore-tests/src/index.ts
+++ b/packages/interface-blockstore-tests/src/index.ts
@@ -87,8 +87,8 @@ export function interfaceBlockstoreTests <B extends Blockstore = Blockstore> (te
 
       let index = 0
 
-      for await (const { cid, block } of store.putMany(data)) {
-        expect(data[index]).to.deep.equal({ cid, block })
+      for await (const cid of store.putMany(data)) {
+        expect(data[index].cid).to.deep.equal(cid)
         index++
       }
 

--- a/packages/interface-datastore-tests/src/index.ts
+++ b/packages/interface-datastore-tests/src/index.ts
@@ -66,8 +66,8 @@ export function interfaceDatastoreTests <D extends Datastore = Datastore> (test:
 
       let index = 0
 
-      for await (const { key, value } of store.putMany(data)) {
-        expect(data[index]).to.deep.equal({ key, value })
+      for await (const key of store.putMany(data)) {
+        expect(data[index].key).to.deep.equal(key)
         index++
       }
 

--- a/packages/interface-store/src/index.ts
+++ b/packages/interface-store/src/index.ts
@@ -45,7 +45,7 @@ export interface Store<Key, Value, Pair, HasOptionsExtension = {},
    * await store.put([{ key: new Key('awesome'), value: new Uint8Array([0, 1, 2, 3]) }])
    * ```
    */
-  put: (key: Key, val: Value, options?: AbortOptions & PutOptionsExtension) => Await<void>
+  put: (key: Key, val: Value, options?: AbortOptions & PutOptionsExtension) => Await<Key>
 
   /**
    * Store the given key/value pairs
@@ -62,7 +62,7 @@ export interface Store<Key, Value, Pair, HasOptionsExtension = {},
   putMany: (
     source: AwaitIterable<Pair>,
     options?: AbortOptions & PutManyOptionsExtension
-  ) => AwaitIterable<Pair>
+  ) => AwaitIterable<Key>
 
   /**
    * Retrieve the value stored under the given key


### PR DESCRIPTION
Otherwise if operating remotely we have the strange property of sending the data to be put once to the receiver and then again back to the sender.